### PR TITLE
CSS fix to render whitespace in the reviews such as paragraphs

### DIFF
--- a/views/reviews.html
+++ b/views/reviews.html
@@ -14,7 +14,7 @@
 						<h5 class="card-title"><%- review.course_id %>: <%- review.title %></h5>
 						<h6 class="card-subtitle mb-2 text-muted"><%- review.timestamp %></h6>
 						<h6 class="card-subtitle mb-2 text-muted"><%- review.session %></h6>
-						<p class="card-text"><%- review.text %></p>
+						<p class="card-text" style="white-space: pre-wrap;"><%- review.text %></p>
 						<h6 class="card-subtitle mb-2">Difficulty: <%- review.difficulty %> / 5</h6>
 						<h6 class="card-subtitle mb-2">Workload: <%- review.workload %> hours / week</h6>
 						<h6 class="card-subtitle mb-2">Rating: <%- review.rating %> / 5</h6>


### PR DESCRIPTION
Closes #28 

Whitespace was being stored in the database, but not rendered due to CSS styling.

I added the `style="white-space: pre-wrap;"` CSS property to render whitespace.