### PR TITLE
Safeguard to protect from undefined SQL results

### DIFF
--- a/routes/main.js
+++ b/routes/main.js
@@ -294,7 +294,7 @@ module.exports = function (app, passport) {
 				message: req.flash("profileMessage"),
 				heading: "Profile",
 				title: "Compass - profile",
-				reviews: result,
+				reviews: typeof result == "undefined" ? [] : result,
 				user: req.user,
 			});
 		});


### PR DESCRIPTION
Added a check for an undefined SQL query result when returning the result using a ternary operator.