### PR TITLE
Store session in MySQL instead of MemoryStore

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const path = require("path");
 const app = express();
 const port = process.env.PORT || 8087;
 const session = require("express-session");
+const MySQLStore = require("express-mysql-session")(session);
 const passport = require("passport");
 const flash = require("connect-flash");
 
@@ -32,6 +33,8 @@ const db = mysql.createConnection({
 	},
 });
 
+const sessionStore = new MySQLStore({}, db);
+
 // connect to database
 db.connect((err) => {
 	if (err) {
@@ -52,8 +55,10 @@ app.use(methodOverride("_method"));
 // create session store. Use memorystore for now and migrate to MySQL later.
 app.use(
 	session({
+		key: "compass-session",
 		secret: process.env.SESSION_SECRET,
-		resave: true,
+		store: sessionStore,
+		resave: false,
 		saveUninitialized: false,
 	})
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -289,6 +289,72 @@
 				"vary": "~1.1.2"
 			}
 		},
+		"express-mysql-session": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/express-mysql-session/-/express-mysql-session-2.1.4.tgz",
+			"integrity": "sha512-Fcq168xVI8jtIJLhVHLJvBCvJlHnFWCcPmtt93UrWH38T2YsB919KrMCCh57/YkECkfff/L5zTQ95K1DxfOixg==",
+			"requires": {
+				"debug": "4.1.1",
+				"express-session": "1.17.0",
+				"mysql": "2.18.1",
+				"underscore": "1.9.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"depd": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+					"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+				},
+				"express-session": {
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.0.tgz",
+					"integrity": "sha512-t4oX2z7uoSqATbMfsxWMbNjAL0T5zpvcJCk3Z9wnPPN7ibddhnmDZXHfEcoBMG2ojKXZoCyPMc5FbtK+G7SoDg==",
+					"requires": {
+						"cookie": "0.4.0",
+						"cookie-signature": "1.0.6",
+						"debug": "2.6.9",
+						"depd": "~2.0.0",
+						"on-headers": "~1.0.2",
+						"parseurl": "~1.3.3",
+						"safe-buffer": "5.2.0",
+						"uid-safe": "~2.1.5"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"ms": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+						}
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				},
+				"safe-buffer": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+					"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+				}
+			}
+		},
 		"express-session": {
 			"version": "1.17.1",
 			"resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.1.tgz",
@@ -1060,6 +1126,11 @@
 			"requires": {
 				"random-bytes": "~1.0.0"
 			}
+		},
+		"underscore": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
+			"integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
 		},
 		"unpipe": {
 			"version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dotenv": "^8.2.0",
     "ejs": "^3.1.5",
     "express": "^4.17.1",
+    "express-mysql-session": "^2.1.4",
     "express-session": "^1.17.1",
     "express-validator": "^6.6.1",
     "method-override": "^3.0.0",


### PR DESCRIPTION
Add `express-mysql-session` package for using mysql as sessionstore.

Now even if server restarts the sessions will persist and users will not have to login again, which is important because slack only login can be tedious to do again and again.

Closes #50