### PR TITLE
Sanitize inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -319,15 +319,6 @@
 				}
 			}
 		},
-		"express-validator": {
-			"version": "6.6.1",
-			"resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.6.1.tgz",
-			"integrity": "sha512-+MrZKJ3eGYXkNF9p9Zf7MS7NkPJFg9MDYATU5c80Cf4F62JdLBIjWxy6481tRC0y1NnC9cgOw8FuN364bWaGhA==",
-			"requires": {
-				"lodash": "^4.17.19",
-				"validator": "^13.1.1"
-			}
-		},
 		"filelist": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.1.tgz",
@@ -410,11 +401,6 @@
 				"filelist": "^1.0.1",
 				"minimatch": "^3.0.4"
 			}
-		},
-		"lodash": {
-			"version": "4.17.20",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 		},
 		"media-typer": {
 			"version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "express": "^4.17.1",
     "express-mysql-session": "^2.1.4",
     "express-session": "^1.17.1",
-    "express-validator": "^6.6.1",
     "method-override": "^3.0.0",
     "mysql": "^2.18.1",
     "passport": "^0.4.1",
-    "passport-slack": "0.0.7"
+    "passport-slack": "0.0.7",
+    "validator": "^13.1.17"
   },
   "devDependencies": {
     "prettier": "^2.1.2"

--- a/views/addreview.html
+++ b/views/addreview.html
@@ -12,7 +12,7 @@
 			<% if (addResult == "success") { %>
 			<div class="alert alert-success" role="alert">Your review was successfully added. Thanks!</div>
 			<% } %>
-			<form action="/added" method="POST" class="mb-4">
+			<form action="/add" method="POST" class="mb-4">
 				<div class="form-group">
 					<label for="module">Module</label>
 					<select
@@ -55,7 +55,7 @@
 
 				<div class="form-group">
 					<label for="workload">How many hours per week did you work?</label>
-					<input class="form-control" type="number" id="workload" name="workload" min="0" max="168" required />
+					<input class="form-control" type="number" id="workload" name="workload" min="0" max="70" required />
 				</div>
 
 				<div class="form-group">
@@ -72,7 +72,7 @@
 
 				<div class="form-group">
 					<label for="text">Your Review</label>
-					<textarea class="form-control" id="text" name="text" rows="4" required></textarea>
+					<textarea class="form-control" id="text" name="text" rows="4" maxlength="8000" required></textarea>
 				</div>
 				<input class="btn btn-primary" type="submit" value="Submit" />
 			</form>

--- a/views/editreview.html
+++ b/views/editreview.html
@@ -70,7 +70,7 @@
 						id="workload"
 						name="workload"
 						min="0"
-						max="168"
+						max="70"
 						value = "<%- review.workload %>"
 						required
 					/>
@@ -94,6 +94,7 @@
 						id="text"
 						name="text"
 						rows="4"
+						maxlength="8000"
 						required
 					><%= review.text %></textarea>
 				</div>


### PR DESCRIPTION
Removed express-validator and using it's parent library validator.js directly. Do `npm install` before testing.

This will now only leave one pending sub-task in #47 - validating session

Sanitize review text and session.
Validate difficulty, rating and workload. If modified by ignoring client side validation, reject review and throw 500 error.
Update max limit for workload from 168 to 70.

Change `/added` route to `/add`