### PR TITLE
Fix bug in deserializing for non-existent user

### DIFF
--- a/config/auth.js
+++ b/config/auth.js
@@ -14,7 +14,12 @@ module.exports = function (passport) {
 	});
 	passport.deserializeUser(function (id, done) {
 		db.query("SELECT * FROM users WHERE id = ? LIMIT 1", [id], function (err, result) {
-			done(err, result[0]);
+			// user does not exist in database
+			if (result.length < 1) {
+				done(err, false);
+			} else {
+				done(err, result[0]);
+			}
 		});
 	});
 


### PR DESCRIPTION
It's unlikely to happen but if database is reset for some reason and session data is lost then users will get 500 error instead of getting logged out. This simple fix eliminates that possibility.

closes #69