### PR TITLE
Add markdown support in review text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,11 @@
 				"color-convert": "^1.9.0"
 			}
 		},
+		"argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+		},
 		"array-flatten": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -173,6 +178,11 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
 			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+		},
+		"entities": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+			"integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
 		},
 		"escape-html": {
 			"version": "1.0.3",
@@ -401,6 +411,31 @@
 				"filelist": "^1.0.1",
 				"minimatch": "^3.0.4"
 			}
+		},
+		"linkify-it": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.2.tgz",
+			"integrity": "sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==",
+			"requires": {
+				"uc.micro": "^1.0.1"
+			}
+		},
+		"markdown-it": {
+			"version": "12.0.2",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.0.2.tgz",
+			"integrity": "sha512-4Lkvjbv2kK+moL9TbeV+6/NHx+1Q+R/NIdUlFlkqkkzUcTod4uiyTJRiBidKR9qXSdkNFkgv+AELY8KN9vSgVA==",
+			"requires": {
+				"argparse": "^2.0.1",
+				"entities": "~2.0.0",
+				"linkify-it": "^3.0.1",
+				"mdurl": "^1.0.1",
+				"uc.micro": "^1.0.5"
+			}
+		},
+		"mdurl": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
 		},
 		"media-typer": {
 			"version": "0.3.0",
@@ -719,6 +754,11 @@
 				"media-typer": "0.3.0",
 				"mime-types": "~2.1.24"
 			}
+		},
+		"uc.micro": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
 		},
 		"uid-safe": {
 			"version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "express": "^4.17.1",
     "express-mysql-session": "^2.1.4",
     "express-session": "^1.17.1",
+    "markdown-it": "^12.0.2",
     "method-override": "^3.0.0",
     "mysql": "^2.18.1",
     "passport": "^0.4.1",

--- a/routes/main.js
+++ b/routes/main.js
@@ -1,4 +1,5 @@
 const validator = require("validator");
+const markdown = require("markdown-it")();
 
 module.exports = function (app, passport) {
 	// List all courses and their scores
@@ -105,6 +106,12 @@ module.exports = function (app, passport) {
 			if (err) {
 				return console.error("Data not found: " + err.message);
 			}
+
+			// Convert markdown to HTML
+			result.forEach((review) => {
+				review.text = markdown.render(review.text);
+			});
+
 			res.render("reviews.html", {
 				title: "Compass – Review " + id[0],
 				heading: "Review #" + id[0],
@@ -155,6 +162,12 @@ module.exports = function (app, passport) {
 			if (err) {
 				return console.error("Data not found: " + err.message);
 			}
+
+			// Convert markdown to HTML
+			result.forEach((review) => {
+				review.text = markdown.render(review.text);
+			});
+
 			res.render("reviews.html", {
 				title: "Compass – Reviews",
 				heading: "Reviews",
@@ -393,3 +406,4 @@ function validateReview(req, res, next) {
 		}
 	});
 }
+

--- a/views/addreview.html
+++ b/views/addreview.html
@@ -74,7 +74,15 @@
 
 				<div class="form-group">
 					<label for="text">Your Review</label>
-					<textarea class="form-control" id="text" name="text" rows="4" maxlength="8000" required></textarea>
+					<textarea
+						class="form-control"
+						id="text"
+						name="text"
+						rows="4"
+						maxlength="8000"
+						placeholder="Write your reivew here. You can use limited Markdown syntax for formatting."
+						required
+					></textarea>
 				</div>
 				<input class="btn btn-primary" type="submit" value="Submit" />
 			</form>


### PR DESCRIPTION
Add markdown rendering support using `markdown-it` package. 

Added hint in `/add` route to suggest that markdown is supported.

closes #33 