### PR TITLE
Hide reviewed courses from addreview

### DIFF
--- a/db/db_setup.sql
+++ b/db/db_setup.sql
@@ -8,7 +8,7 @@ DROP TABLE IF EXISTS courses;
 
 DROP TABLE IF EXISTS users;
 
-DROP TABLE IF EXISTS semesters; 
+DROP TABLE IF EXISTS semesters;
 
 CREATE TABLE `courses` (
 	`id` VARCHAR(6),
@@ -37,7 +37,8 @@ CREATE TABLE `reviews` (
 	`text` TEXT,
 	PRIMARY KEY (`id`),
 	FOREIGN KEY (course_id) REFERENCES courses(id),
-	FOREIGN KEY (user_id) REFERENCES users(id)
+	FOREIGN KEY (user_id) REFERENCES users(id),
+	UNIQUE (course_id, user_id)
 );
 
 CREATE TABLE `semesters` (

--- a/public/js/editreview.js
+++ b/public/js/editreview.js
@@ -1,2 +1,2 @@
-const semester = JSON.parse(reviewSemester) //get session
-$('#semester').selectpicker('val', semester); //set as selected
+const semester = JSON.parse(reviewSemester); //get session
+$("#semester").selectpicker("val", semester); //set as selected

--- a/routes/main.js
+++ b/routes/main.js
@@ -216,7 +216,7 @@ module.exports = function (app, passport) {
 				reviewResult[0].text = validator.unescape(reviewResult[0].text);
 
 				res.render("editreview.html", {
-					message: req.flash("editReviewMessage"),
+					infoMessage: req.flash("info"),
 					title: "Compass – Edit Review ",
 					heading: "Edit Review #" + id[0],
 					review: reviewResult[0],
@@ -241,10 +241,12 @@ module.exports = function (app, passport) {
 		let entry = [req.body.semester, req.body.difficulty, req.body.workload, req.body.rating, req.body.text, req.params.id];
 		db.query(sqlquery, entry, (err, result) => {
 			if (err) {
-				req.flash("editReviewMessage", "Could not update review");
+				req.flash("info", "Could not update review");
 				res.redirect("/review/" + req.params.id + "/update");
 			} else {
-				req.flash("editReviewMessage", "Review updated.");
+				let link = "/review/" + req.params.id;
+				let message = 'Review updated. <a href="' + link + '">Visit</a>';
+				req.flash("info", message);
 				res.redirect("/review/" + req.params.id + "/update");
 			}
 		});
@@ -256,9 +258,10 @@ module.exports = function (app, passport) {
 		let id = [req.params.id];
 		db.query(sqlquery, id, (err, result) => {
 			if (err) {
-				req.flash("editReviewMessage", "Could not delete review");
+				req.flash("info", "Could not delete review");
 				res.redirect("/review/" + req.params.id + "/update");
 			} else {
+				req.flash("info", "Review deleted.");
 				res.redirect("/profile");
 			}
 		});
@@ -295,6 +298,7 @@ module.exports = function (app, passport) {
 				title: "Compass - profile",
 				reviews: typeof result == "undefined" ? [] : result,
 				user: req.user,
+				infoMessage: req.flash("info"),
 				errorMessage: req.flash("error"),
 				warningMessage: req.flash("warning"),
 			});

--- a/routes/main.js
+++ b/routes/main.js
@@ -79,8 +79,8 @@ module.exports = function (app, passport) {
 		let newrecord = [req.user.id, req.body.course_id, req.body.semester, req.body.difficulty, req.body.workload, req.body.rating, req.body.text];
 		db.query(sqlquery, newrecord, (err, result) => {
 			if (err) {
-				res.send("The review couldn't be added. Try again.");
-				return console.error(err.message);
+				console.error(err.message);
+				return res.status(500).send("<h1>500: Internal server error</h1>");
 			} else res.redirect("../add/?addResult=success");
 		});
 	});

--- a/views/addreview.html
+++ b/views/addreview.html
@@ -80,7 +80,7 @@
 						name="text"
 						rows="4"
 						maxlength="8000"
-						placeholder="Write your reivew here. You can use limited Markdown syntax for formatting."
+						placeholder="Write your review here. You can use limited Markdown syntax for formatting."
 						required
 					></textarea>
 				</div>

--- a/views/editreview.html
+++ b/views/editreview.html
@@ -10,8 +10,8 @@
 			<h1><%- heading %></h1>
 
 			<!-- Flash Message -->
-			<% if (message.length > 0) { %>
-				<div class="alert alert-warning"><%= message %> <a href="/review/<%= review.id %>">Visit review</a></div>
+			<% if (infoMessage.length > 0) { %>
+				<div class="alert alert-info"><%- infoMessage %></div>
 			<% } %>
 
 			<!-- Form -->

--- a/views/profile.html
+++ b/views/profile.html
@@ -7,6 +7,9 @@
 			<h1><%- heading %></h1>
 
 			<!-- alerts -->
+			<% if (infoMessage.length > 0) { %>
+			<div class="alert alert-info"><%= infoMessage %></div>
+			<% } %>
 			<% if (errorMessage.length > 0) { %>
 			<div class="alert alert-danger"><%= errorMessage %></div>
 			<% } %>


### PR DESCRIPTION
Replaces PR https://github.com/world-class/compass/pull/76
Closes https://github.com/world-class/compass/issues/72

I added the flash message changes because they went along with the initial changes that we have since scrapped (rerouting/flash messages when user submits review for course they already reviewed). They are an improvement over what we had but they are less obvious, so I will explain them here:

- the delete route now reroutes to the profile and confirms the action in the flash message
- update flash message no longer hard-codes link (now only shows on successful update)
- further standardized flash message names (changed `editReview` to `info`)