### PR TITLE
Add emoji support and switch mysql to utf8mb4

### DIFF
--- a/db/add_dummy_reviews.sql
+++ b/db/add_dummy_reviews.sql
@@ -1,7 +1,32 @@
-INSERT INTO 
+INSERT INTO
 	reviews(user_id, course_id, semester, difficulty, workload, rating, text)
 VALUES
 	(1, 'CM1005', 'October to March 2020', 2, 3, 4, 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'),
 	(1, 'CM1010', 'April to September 2020', 3, 4, 3, 'Est ante in nibh mauris cursus mattis.'),
     (1, 'CM1015', 'October to March 2020', 4, 4, 2, 'Commodo elit at imperdiet dui.'),
-	(1, 'CM1005', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.');
+	(1, 'CM1020', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM1025', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM1030', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM1035', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM1040', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM2005', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM2010', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM2015', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM2020', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM2025', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM2030', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM2035', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM2040', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM3005', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM3010', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM3015', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM3020', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM3025', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM3030', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM3035', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM3040', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM3045', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM3050', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM3055', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM3060', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.'),
+	(1, 'CM3070', 'April to September 2020', 3, 4, 3, 'Mattis aliquam faucibus purus in massa tempor.');

--- a/db/db_setup.sql
+++ b/db/db_setup.sql
@@ -1,4 +1,6 @@
-CREATE DATABASE IF NOT EXISTS compass_db;
+CREATE DATABASE IF NOT EXISTS compass_db
+DEFAULT CHARSET = utf8mb4
+DEFAULT COLLATE = utf8mb4_unicode_ci;
 
 USE compass_db;
 
@@ -15,7 +17,7 @@ CREATE TABLE `courses` (
 	`title` VARCHAR(100),
 	`required` BIT,
 	PRIMARY KEY (`id`)
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 CREATE TABLE `users` (
     `id` INT NOT NULL AUTO_INCREMENT,
@@ -23,7 +25,7 @@ CREATE TABLE `users` (
     `email` VARCHAR(80),
     `slackuid` VARCHAR(25) NOT NULL UNIQUE,
     PRIMARY KEY (`id`)
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 CREATE TABLE `reviews` (
 	`id` INT NOT NULL AUTO_INCREMENT,
@@ -36,14 +38,14 @@ CREATE TABLE `reviews` (
 	`rating` TINYINT,
 	`text` TEXT,
 	PRIMARY KEY (`id`),
-	FOREIGN KEY (course_id) REFERENCES courses(id),
-	FOREIGN KEY (user_id) REFERENCES users(id),
-	UNIQUE (course_id, user_id)
-);
+	FOREIGN KEY (`course_id`) REFERENCES courses(`id`),
+	FOREIGN KEY (`user_id`) REFERENCES users(`id`),
+	unique (course_id, user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 CREATE TABLE `semesters` (
 	`id` INT NOT NULL AUTO_INCREMENT,
 	`name_string` VARCHAR(50),
 	`start_date` DATE,
 	PRIMARY KEY (`id`)
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ const db = mysql.createConnection({
 	user: process.env.DB_USER,
 	password: process.env.DB_PASSWORD,
 	database: process.env.DB_DATABASE,
+	charset: "utf8mb4",
 	typeCast: function castField(field, useDefaultTypeCasting) {
 		// Cast bit fields that have a single-bit in them to a boolean
 		// Without this, 'bit' fields will not return as true/false


### PR DESCRIPTION
`utf8mb4` should allow for emojis in review text. Also specified mysql engine to `InnoDB`. 

Remove local database `compass_db` before testing. 

Closes #82 