### PR TITLE
Escape reviews heading to prevent XSS

### DIFF
--- a/views/reviews.html
+++ b/views/reviews.html
@@ -7,7 +7,7 @@
 		<%- include('partials/nav.ejs') %>
 		<div class="container">
 			<!-- Page content begins below this -->
-			<h1><%- heading %></h1>
+			<h1><%= heading %></h1>
 			<a href="/reviews/add<%- typeof filteredModule !== 'undefined' ? '?course_id=' + filteredModule : '' %>"
 				class="btn btn-primary mb-4" >Add a review</a>
 			<% if (typeof reviews === 'undefined' || reviews.length < 1) { %>


### PR DESCRIPTION
Escapes the heading on the reviews page to prevent XSS.

For example changing `course_id` on the reviews page to `/reviews?course_id=<script>alert(document.cookie)</script>` shows an alert.